### PR TITLE
Fixing stepwise `.remove` error

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -214,7 +214,7 @@
     "        worst_pval = pvalues.max() # null if pvalues is empty\n",
     "        if worst_pval > threshold_out:\n",
     "            changed=True\n",
-    "            worst_feature = pvalues.argmax()\n",
+    "            worst_feature = pvalues.idxmax()\n",
     "            included.remove(worst_feature)\n",
     "            if verbose:\n",
     "                print('Drop {:30} with p-value {:.6}'.format(worst_feature, worst_pval))\n",

--- a/index.ipynb
+++ b/index.ipynb
@@ -153,7 +153,7 @@
     "        worst_pval = pvalues.max() # null if pvalues is empty\n",
     "        if worst_pval > threshold_out:\n",
     "            changed=True\n",
-    "            worst_feature = pvalues.argmax()\n",
+    "            worst_feature = pvalues.idxmax()\n",
     "            included.remove(worst_feature)\n",
     "            if verbose:\n",
     "                print('Drop {:30} with p-value {:.6}'.format(worst_feature, worst_pval))\n",
@@ -314,13 +314,7 @@
       "/Users/lore.dirick/anaconda3/lib/python3.6/site-packages/numpy/core/fromnumeric.py:2389: FutureWarning: Method .ptp is deprecated and will be removed in a future version. Use numpy.ptp instead.\n",
       "  return ptp(axis=axis, out=out, **kwargs)\n",
       "/Users/lore.dirick/anaconda3/lib/python3.6/site-packages/numpy/core/fromnumeric.py:2389: FutureWarning: Method .ptp is deprecated and will be removed in a future version. Use numpy.ptp instead.\n",
-      "  return ptp(axis=axis, out=out, **kwargs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  return ptp(axis=axis, out=out, **kwargs)\n",
       "/Users/lore.dirick/anaconda3/lib/python3.6/site-packages/numpy/core/fromnumeric.py:2389: FutureWarning: Method .ptp is deprecated and will be removed in a future version. Use numpy.ptp instead.\n",
       "  return ptp(axis=axis, out=out, **kwargs)\n",
       "/Users/lore.dirick/anaconda3/lib/python3.6/site-packages/numpy/core/fromnumeric.py:2389: FutureWarning: Method .ptp is deprecated and will be removed in a future version. Use numpy.ptp instead.\n",
@@ -864,7 +858,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -878,9 +872,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
### The issue

In line 46 of the `stepwise_selection` function, we wish to remove features from an OLS model if the `p-value` for the feature is above a set threshold (defaults to `0.05`)

The feature with the highest p-value is being identified within a pandas series object, where the feature names are set as the index and the p-values are set as the values. The current version of this code sets `worst_feature` to the result of `series.argmax()` [which returns the integer index](https://numpy.org/doc/stable/reference/generated/numpy.argmax.html) for the feature name rather than the feature name itself. 

The feature is then removed from the list of model features via `list.remove(<result of argmax>)`. The `.remove` method expects the actual datapoint, not the integer index, so this results in a `ValueError: list.remove(x): x not in list`. 

### Solution

Line 46 has been changed from...
```python
worst_feature = pvalues.argmax()
```

...to:
```python
worst_feature = pvalues.idxmax()
```
